### PR TITLE
Fix importing/exporting data sets with more than 26 columns/attributes

### DIFF
--- a/behaviors/importexportcontroller/ImportsData.php
+++ b/behaviors/importexportcontroller/ImportsData.php
@@ -3,6 +3,7 @@
 namespace SKasianov\ExcelImportExport\Behaviors\ImportExportController;
 
 use ApplicationException;
+use PhpOffice\PhpSpreadsheet\Cell\Coordinate;
 use PhpOffice\PhpSpreadsheet\IOFactory;
 use PhpOffice\PhpSpreadsheet\Reader\IReader;
 
@@ -35,11 +36,11 @@ trait ImportsData
         ]);
 
         $sheet = $spreadsheet->getActiveSheet();
+        $highestColumn = $sheet->getHighestColumn();
 
         if (! post('first_row_titles')) {
             $headers = [];
-            $alphabet = array_flip(range('A', 'Z'));
-            $columnsCount = $alphabet[$sheet->getHighestColumn()] + 1;
+            $columnsCount = Coordinate::columnIndexFromString($highestColumn);
 
             for ($i = 1; $i <= $columnsCount; $i++) {
                 $headers[] = 'Column #'.$i;
@@ -48,7 +49,7 @@ trait ImportsData
             return $headers;
         }
 
-        $data = $sheet->rangeToArray('A1:'.$sheet->getHighestColumn(). 1);
+        $data = $sheet->rangeToArray('A1:'.$highestColumn. 1);
 
         return $data[0];
     }

--- a/models/ExportModel.php
+++ b/models/ExportModel.php
@@ -3,6 +3,7 @@
 namespace SKasianov\ExcelImportExport\Models;
 
 use ApplicationException;
+use PhpOffice\PhpSpreadsheet\Cell\Coordinate;
 use PhpOffice\PhpSpreadsheet\Spreadsheet;
 use PhpOffice\PhpSpreadsheet\Writer\Ods;
 use PhpOffice\PhpSpreadsheet\Writer\Xls;
@@ -76,27 +77,22 @@ abstract class ExportModel extends \Backend\Models\ExportModel
         $spreadsheet = new Spreadsheet();
         $sheet = $spreadsheet->getActiveSheet();
 
-        $alphabet = range('A', 'Z');
-
         $rowNum = 1;
         if ($options['firstRowTitles']) {
-            $colNum = 0;
+            $colNum = 1;
             foreach ($columns as $column) {
-                $letter = $alphabet[$colNum];
+                $letter = Coordinate::stringFromColumnIndex($colNum++);
                 $sheet->setCellValue("$letter$rowNum", __($column));
-                $colNum++;
             }
-
-            $rowNum = 2;
+            $rowNum++;
         }
 
         foreach ($results as $record) {
-            $colNum = 0;
+            $colNum = 1;
             $rowData = $this->matchDataToColumns($record, $columns);
             foreach ($rowData as $value) {
-                $letter = $alphabet[$colNum];
+                $letter = Coordinate::stringFromColumnIndex($colNum++);
                 $sheet->setCellValue("$letter$rowNum", $value);
-                $colNum++;
             }
             $rowNum++;
         }


### PR DESCRIPTION
For more than 26 columns, A-Z range is not enough.

When importing more than 26 columns, this error occurs: `"Undefined array key "AE"" on line 45 of /plugins/skasianov/excelimportexport/behaviors/importexportcontroller/ImportsData.php`

When exporting more than 26 attributes, this error occurs: `"Undefined array key 26" on line 87 of /plugins/skasianov/excelimportexport/models/ExportModel.php`