### PR TITLE
Loading sample data for import form

### DIFF
--- a/behaviors/importexportcontroller/ImportsData.php
+++ b/behaviors/importexportcontroller/ImportsData.php
@@ -3,12 +3,49 @@
 namespace SKasianov\ExcelImportExport\Behaviors\ImportExportController;
 
 use ApplicationException;
+use Str;
 use PhpOffice\PhpSpreadsheet\Cell\Coordinate;
 use PhpOffice\PhpSpreadsheet\IOFactory;
 use PhpOffice\PhpSpreadsheet\Reader\IReader;
 
 trait ImportsData
 {
+    public function actionImportLoadColumnSampleForm()
+    {
+        if (($columnId = post('file_column_id', false)) === false) {
+            throw new ApplicationException(__("Missing column identifier"));
+        }
+
+        $columns = $this->getImportFileColumns();
+        if (!array_key_exists($columnId, $columns)) {
+            throw new ApplicationException(__("Unknown column"));
+        }
+
+        $path = $this->getImportFilePath();
+
+        if (!$fileFormat = post('file_format', 'json')) {
+            return null;
+        }
+
+        $data = match ($fileFormat) {
+            'json' => $this->getImportSampleColumnsFromJson($path, (int) $columnId),
+            'csv', 'csv_custom' => $this->getImportSampleColumnsFromCsv($path, (int) $columnId),
+            'xlsx', 'xls', 'ods' => $this->getImportSampleColumnsFromSpreadsheet($path, (int) $columnId),
+            default => throw new ApplicationException('Unsupported file format'),
+        };
+
+        // Clean up data
+        foreach ($data as $index => $sample) {
+            $data[$index] = Str::limit($sample, 100);
+            if (!strlen($data[$index])) {
+                unset($data[$index]);
+            }
+        }
+
+        $this->vars['columnName'] = array_get($columns, $columnId);
+        $this->vars['columnData'] = $data;
+    }
+
     protected function getImportFileColumns()
     {
         if (! $path = $this->getImportFilePath()) {
@@ -52,5 +89,39 @@ trait ImportsData
         $data = $sheet->rangeToArray('A1:'.$highestColumn. 1);
 
         return $data[0];
+    }
+
+    protected function getImportSampleColumnsFromSpreadsheet($path, $columnIndex)
+    {
+        $spreadsheet = IOFactory::load($path, IReader::READ_DATA_ONLY, [
+            IOFactory::READER_XLSX,
+            IOFactory::READER_XLS,
+            IOFactory::READER_ODS,
+        ]);
+
+        // init
+        $fromRow = 1;
+        $limit = 50;
+        $columnIndex++;
+        $sheet = $spreadsheet->getActiveSheet();
+
+        // if selected column without any data
+        $highestColumn = $sheet->getHighestColumn();
+        $highestColumnIndex = Coordinate::columnIndexFromString($highestColumn);
+        if ($columnIndex > $highestColumnIndex) {
+            return [];
+        }
+
+        // init range
+        if (!post('first_row_titles')) {
+            $fromRow++;
+        }
+        $toRow = $fromRow + $limit;
+
+        // read sample data from selected column
+        $selectedColumn = Coordinate::stringFromColumnIndex($columnIndex);
+        $data = $sheet->rangeToArray($selectedColumn . $fromRow . ':' . $selectedColumn . $toRow);
+
+        return array_column($data, 0);
     }
 }


### PR DESCRIPTION
Add XLS format for method `actionImportLoadColumnSampleForm` which is responsible for loading sample data when clicking on column name here:

<img width="533" height="312" alt="Screenshot 2025-09-05 v 11 42 12" src="https://github.com/user-attachments/assets/b33c799f-1789-4cd0-ab05-00c89afaaa50" />

Without this update, it sometimes returns weird data oran  error:

<img width="613" height="212" alt="Screenshot 2025-09-05 v 11 48 57" src="https://github.com/user-attachments/assets/abb5d003-4296-4e17-a240-83f19eae4b3a" />
